### PR TITLE
Pair coding 17 10 03

### DIFF
--- a/src/helper.js
+++ b/src/helper.js
@@ -10,9 +10,9 @@ export default class DistrictRepository {
       if (!acc[currentLocation]) {
         acc[currentLocation] = {};
       }
-      acc[currentLocation][item.TimeFrame] = {
-        DataFormat: item.DataFormat,
-        Data: item.Data,
+      acc[currentLocation][item.TimeFrame] = item
+      if (typeof acc[currentLocation][item.TimeFrame].Data != 'number') {
+        acc[currentLocation][item.TimeFrame].Data = 0;
       }
       return acc;
     },{})
@@ -27,7 +27,7 @@ export default class DistrictRepository {
       return {
         location: queryUppercase,
         data: Object.keys(this.data[queryUppercase]).reduce( (acc, year) => {
-          acc[year] = parseFloat(this.data[queryUppercase][year].Data).toFixed(3));
+          acc[year] = parseFloat((this.data[queryUppercase][year].Data).toFixed(3));
           return acc
         }, {})
       }

--- a/src/helper.js
+++ b/src/helper.js
@@ -6,7 +6,8 @@ export default class DistrictRepository {
     let cleanData = {};
 
     cleanData = dataArrayToClean.reduce( (acc, item) => {
-      let currentLocation = item.Location.toUpperCase();
+      const currentLocation = item.Location.toUpperCase();
+
       if (!acc[currentLocation]) {
         acc[currentLocation] = {};
       }
@@ -20,7 +21,7 @@ export default class DistrictRepository {
   }
 
   findByName(query = 'no query entered') {
-    let queryUppercase = query.toUpperCase();
+    const queryUppercase = query.toUpperCase();
     if (!this.data[queryUppercase]) {
       return
     } else {
@@ -35,7 +36,7 @@ export default class DistrictRepository {
   }
 
   findAllMatches(query = '') {
-    let queryUppercase = query.toUpperCase();
+    const queryUppercase = query.toUpperCase();
     let returnArray = [];
 
     returnArray = Object.keys(this.data).reduce( (acc, location) => {
@@ -45,6 +46,19 @@ export default class DistrictRepository {
       return acc
     }, []);
     return returnArray
+  }
+
+  findAverage(query) {
+    const queryUppercase = query.toUpperCase();
+    const averageData = this.findByName(queryUppercase);
+    let total = 0;
+
+    total = Object.keys(averageData.data).reduce( (acc, year) => {
+      acc += averageData.data[year]
+      return acc;
+    }, 0)
+
+    return parseFloat((total/Object.keys(averageData.data).length).toFixed(3))
   }
 
 }

--- a/src/helper.js
+++ b/src/helper.js
@@ -32,7 +32,19 @@ export default class DistrictRepository {
         }, {})
       }
     }
+  }
 
+  findAllMatches(query = '') {
+    let queryUppercase = query.toUpperCase();
+    let returnArray = [];
+
+    returnArray = Object.keys(this.data).reduce( (acc, location) => {
+      if ( location.includes(queryUppercase) ) {
+        acc.push(this.data[location])
+      }
+      return acc
+    }, []);
+    return returnArray
   }
 
 }

--- a/src/helper.js
+++ b/src/helper.js
@@ -61,4 +61,25 @@ export default class DistrictRepository {
     return parseFloat((total/Object.keys(averageData.data).length).toFixed(3))
   }
 
+  compareDistrictAverages(location1, location2) {
+    const location1Uppercase = location1.toUpperCase();
+    const location2Uppercase = location2.toUpperCase();
+    const location1Average = this.findAverage(location1Uppercase);
+    const location2Average = this.findAverage(location2Uppercase);
+
+    return {
+      [location1Uppercase]: location1Average,
+      [location2Uppercase]: location2Average,
+      compared: this.findCompared(location1Average, location2Average),
+    }
+  }
+
+  findCompared(avg1, avg2) {
+    if (avg1 >= avg2) {
+      return parseFloat((avg2/avg1).toFixed(3))
+    } else {
+      return parseFloat((avg1/avg2).toFixed(3))
+    }
+  }
+
 }

--- a/src/helper.js
+++ b/src/helper.js
@@ -21,13 +21,15 @@ export default class DistrictRepository {
 
   findByName(query = 'no query entered') {
     let queryUppercase = query.toUpperCase();
-    // test queryUppercase against existing data in this.data
-    // if there's no match, return undefined
     if (!this.data[queryUppercase]) {
       return
     } else {
       return {
         location: queryUppercase,
+        data: Object.keys(this.data[queryUppercase]).reduce( (acc, year) => {
+          acc[year] = parseFloat(this.data[queryUppercase][year].Data).toFixed(3));
+          return acc
+        }, {})
       }
     }
 


### PR DESCRIPTION
Add code to pass all provided test files.

Current implementation of compareDistrictAverages in helper.js always returns the ratio of the lower performing district compared to the higher (i.e. averages of 1 and 0.5 return compared of 0.500 instead of 2.000) 
We discussed allowing the first entered to be a ratio of the second, but the information would include compared values greater than 1 (100%) in some situations. We decided that is less clear for end users and restricted the value of compared to be 1 or less.