### PR TITLE
add jest-css-modules package to be able to run tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5677,6 +5677,68 @@
         "json-stable-stringify": "1.0.1"
       }
     },
+    "jest-css-modules": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jest-css-modules/-/jest-css-modules-1.1.0.tgz",
+      "integrity": "sha1-GTMs92dhjmBS8JAN4l5riFnmW5U=",
+      "dev": true,
+      "requires": {
+        "babel-jest": "16.0.0"
+      },
+      "dependencies": {
+        "babel-jest": {
+          "version": "16.0.0",
+          "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-16.0.0.tgz",
+          "integrity": "sha1-NIcprqbWJKR3S4qTTQekDdLP1kA=",
+          "dev": true,
+          "requires": {
+            "babel-core": "6.22.1",
+            "babel-plugin-istanbul": "2.0.3",
+            "babel-preset-jest": "16.0.0"
+          }
+        },
+        "babel-plugin-istanbul": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-2.0.3.tgz",
+          "integrity": "sha1-JmswS5EJYH1gdIR0OUZ2mC9mDfQ=",
+          "dev": true,
+          "requires": {
+            "find-up": "1.1.2",
+            "istanbul-lib-instrument": "1.8.0",
+            "object-assign": "4.1.1",
+            "test-exclude": "2.1.3"
+          }
+        },
+        "babel-plugin-jest-hoist": {
+          "version": "16.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-16.0.0.tgz",
+          "integrity": "sha1-tYyj93CYKn58JbVhSy5X6dr8bnY=",
+          "dev": true
+        },
+        "babel-preset-jest": {
+          "version": "16.0.0",
+          "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-16.0.0.tgz",
+          "integrity": "sha1-QXqrwtfZMXD0PCDvHqAUXo9/LbU=",
+          "dev": true,
+          "requires": {
+            "babel-plugin-jest-hoist": "16.0.0"
+          }
+        },
+        "test-exclude": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-2.1.3.tgz",
+          "integrity": "sha1-qNiWjh2oMmb5hk8oUsVeIg8GQ0o=",
+          "dev": true,
+          "requires": {
+            "arrify": "1.0.1",
+            "micromatch": "2.3.11",
+            "object-assign": "4.1.1",
+            "read-pkg-up": "1.0.1",
+            "require-main-filename": "1.0.1"
+          }
+        }
+      }
+    },
     "jest-diff": {
       "version": "18.1.0",
       "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-18.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -10,10 +10,15 @@
     "enzyme-adapter-react-15": "^1.0.1",
     "eslint": "^4.8.0",
     "eslint-plugin-react": "^7.4.0",
+    "jest-css-modules": "^1.1.0",
     "node-sass-chokidar": "0.0.3",
     "react-scripts": "0.9.0",
     "react-test-renderer": "^15.6.2"
   },
+   "jest": {
+    "scriptPreprocessor": "<rootDir>/node_modules/jest-css-modules"
+  }
+  ,
   "dependencies": {
     "jest-enzyme": "^4.0.0",
     "npm-run-all": "^4.1.1",


### PR DESCRIPTION
Add jest-css-modules package to fix problem with tests not running because components cannot locate css files that are being imported into them.